### PR TITLE
add support for proxy of openai api 

### DIFF
--- a/ChatReviewerAndResponse/chat_response.py
+++ b/ChatReviewerAndResponse/chat_response.py
@@ -37,6 +37,7 @@ class Response:
         self.config.read('apikey.ini')
         OPENAI_KEY = os.environ.get("OPENAI_KEY", "")
         # 获取某个键对应的值
+        openai.api_base = self.config.get('OpenAI', 'OPENAI_API_BASE')    
         self.chat_api_list = self.config.get('OpenAI', 'OPENAI_API_KEYS')[1:-1].replace('\'', '').split(',')
         self.chat_api_list.append(OPENAI_KEY)
 

--- a/ChatReviewerAndResponse/chat_reviewer.py
+++ b/ChatReviewerAndResponse/chat_reviewer.py
@@ -69,7 +69,8 @@ class Reviewer:
         self.config = configparser.ConfigParser()
         # 读取配置文件
         self.config.read('apikey.ini')
-        # 获取某个键对应的值        
+        # 获取某个键对应的值     
+        openai.api_base = self.config.get('OpenAI', 'OPENAI_API_BASE')       
         self.chat_api_list = self.config.get('OpenAI', 'OPENAI_API_KEYS')[1:-1].replace('\'', '').split(',')
         self.chat_api_list = [api.strip() for api in self.chat_api_list if len(api) > 5]
         self.cur_api = 0

--- a/apikey.ini
+++ b/apikey.ini
@@ -1,6 +1,8 @@
 [OpenAI]
 introduction = the api key does not ''
 OPENAI_API_KEYS = [sk-xxxx, ]
+# the base URL for openai or other proxy
+OPENAI_API_BASE = https://api.openai.com/v1
 CHATGPT_MODEL = gpt-3.5-turbo-0613
 
 [AzureOPenAI]

--- a/chat_arxiv.py
+++ b/chat_arxiv.py
@@ -322,7 +322,8 @@ class Reader:
         # 读取配置文件
         self.config.read('apikey.ini')
         OPENAI_KEY = os.environ.get("OPENAI_KEY", "")
-        # 获取某个键对应的值        
+        # 获取某个键对应的值
+        openai.api_base = self.config.get('OpenAI', 'OPENAI_API_BASE')    
         self.chat_api_list = self.config.get('OpenAI', 'OPENAI_API_KEYS')[1:-1].replace('\'', '').split(',')
         self.chat_api_list.append(OPENAI_KEY)
 

--- a/chat_paper.py
+++ b/chat_paper.py
@@ -303,6 +303,7 @@ class Reader:
         self.config.read('apikey.ini')
         OPENAI_KEY = os.environ.get("OPENAI_KEY", "")
         # 获取某个键对应的值
+        openai.api_base = self.config.get('OpenAI', 'OPENAI_API_BASE')
         self.chat_api_list = self.config.get('OpenAI', 'OPENAI_API_KEYS')[1:-1].replace('\'', '').split(',')
         self.chat_api_list.append(OPENAI_KEY)
 

--- a/chat_translate.py
+++ b/chat_translate.py
@@ -153,11 +153,12 @@ def chat_check_domain(text, key):
     info['response_time'] = response.response_ms / 1000.0
     return info
 
-def main(root_path, pdf_path, key, task="翻译"):
+def main(root_path, pdf_path, base_url, key, task="翻译"):
     md_file = root_path + pdf_path.split("/")[-1].replace(".pdf", '.md')
     md_str = "\n"        
     token_consumed = 0
-    paper_pdf = parse_pdf(pdf_path)    
+    paper_pdf = parse_pdf(pdf_path)
+
     
     tokenizer_gpt35 = LazyloadTiktoken("gpt-3.5-turbo")
     
@@ -173,7 +174,7 @@ def main(root_path, pdf_path, key, task="翻译"):
     print("这篇文章的domain是：", domains)
     
     # input("继续？")
-        
+    openai.api_base = base_url   
     # 先把标题翻译了
     if "title" in paper_pdf.keys():
         text = paper_pdf['title']
@@ -220,7 +221,7 @@ def main(root_path, pdf_path, key, task="翻译"):
 if __name__ == "__main__":
     root_path = r'./'
     pdf_path = r'./demo.pdf'
-
+    base_url = 'https://api.openai.com/v1'
     key = "sk-xxx"
     task = "翻译"
-    main(root_path, pdf_path, key, task)
+    main(root_path, pdf_path, base_url, key, task)


### PR DESCRIPTION
Add `OPENAI_API_BASE = https://api.openai.com/v1` in the apikey.ini file for default value.

And the user can change it for proxy url of openai to avoid using system proxy.