### PR TITLE
Fix undefined "args" var in chat reviewer

### DIFF
--- a/ChatReviewerAndResponse/chat_reviewer.py
+++ b/ChatReviewerAndResponse/chat_reviewer.py
@@ -77,6 +77,7 @@ class Reviewer:
         self.file_format = args.file_format        
         self.max_token_num = 4096
         self.encoding = tiktoken.get_encoding("gpt2")
+        self.research_fields = args.research_fields
     
     def validateTitle(self, title):
         # 修正论文的路径格式
@@ -135,7 +136,7 @@ class Reviewer:
         self.cur_api = 0 if self.cur_api >= len(self.chat_api_list)-1 else self.cur_api
         messages = [
             {"role": "system",
-             "content": f"You are a professional reviewer in the field of {args.research_fields}. "
+             "content": f"You are a professional reviewer in the field of {self.research_fields}. "
                         f"I will give you a paper. You need to review this paper and discuss the novelty and originality of ideas, correctness, clarity, the significance of results, potential impact and quality of the presentation. "
                         f"Due to the length limitations, I am only allowed to provide you the abstract, introduction, conclusion and at most two sections of this paper."
                         f"Now I will give you the title and abstract and the headings of potential sections. "
@@ -171,7 +172,7 @@ class Reviewer:
         with open('ReviewFormat.txt', 'r') as file:   # 读取特定的审稿格式
             review_format = file.read()
         messages=[
-                {"role": "system", "content": "You are a professional reviewer in the field of "+args.research_fields+". Now I will give you a paper. You need to give a complete review opinion according to the following requirements and format:"+ review_format +" Please answer in {}.".format(self.language)},
+                {"role": "system", "content": "You are a professional reviewer in the field of "+self.research_fields+". Now I will give you a paper. You need to give a complete review opinion according to the following requirements and format:"+ review_format +" Please answer in {}.".format(self.language)},
                 {"role": "user", "content": input_text},
             ]
                 


### PR DESCRIPTION
目前的版本在命令行运行 `chat_reviewer.py` 会提示变量 args 未定义，经检查是代码本身的问题，此PR修复了此问题

```txt
(venv) root@VM-0-11-debian:~/ChatPaper/ChatReviewerAndResponse# python chat_reviewer.py --paper_path . 
root: . dirs: ['__pycache__', 'output_file'] files: ['review_comments.txt', 'ReviewFormat.txt', 'get_paper.py', 'README.md', 'chat_response.py', 'paper_file.pdf', 'chat_reviewer.py', 'apikey.ini']
root: ./__pycache__ dirs: [] files: ['get_paper.cpython-311.pyc']
root: ./output_file dirs: [] files: ['paper_title_secret.txt', 'paper_title_secret.txt']
------------------paper_num: 1------------------
0 ./paper_file.pdf
Traceback (most recent call last):
  File "/root/ChatPaper/ChatReviewerAndResponse/chat_reviewer.py", line 233, in <module>
    chat_reviewer_main(args=reviewer_args)
  File "/root/ChatPaper/ChatReviewerAndResponse/chat_reviewer.py", line 220, in chat_reviewer_main
    reviewer1.review_by_chatgpt(paper_list=paper_list)
  File "/root/ChatPaper/ChatReviewerAndResponse/chat_reviewer.py", line 91, in review_by_chatgpt
    sections_of_interest = self.stage_1(paper)
                           ^^^^^^^^^^^^^^^^^^^
  File "/root/ChatPaper/ChatReviewerAndResponse/chat_reviewer.py", line 138, in stage_1
    "content": f"You are a professional reviewer in the field of {args.research_fields}. "
                                                                  ^^^^
NameError: name 'args' is not defined
```
